### PR TITLE
Made "model" parameter optional for action "generate"

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -43,7 +43,6 @@ actions:
         type: string
         description: "The prompt you want to give to the LLM"
     required:
-    - model
     - prompt
     additionalProperties: false
   pull:


### PR DESCRIPTION
The `model` parameter for action `generate` is now optional.

If you do not provide any `model` parameter, the charm will choose one of the models you have pulled to run the prompt.

If you have not pulled any model, then you will get an error message.